### PR TITLE
Add testauth API demo

### DIFF
--- a/testauth/README.md
+++ b/testauth/README.md
@@ -1,0 +1,32 @@
+# testauth
+
+This small project demonstrates how to call the authorisation API.
+
+## API Endpoint
+
+```
+https://user.monocle-dev.wld.ssdgws.co.uk/api/v0/client/authorise
+```
+
+## Example Payload
+
+```json
+{
+  "clientId": "client-001",
+  "clientSecret": "auth-secret-for-client-001",
+  "scopes": [
+    "ORGANISATION",
+    "PATIENT"
+  ]
+}
+```
+
+## Usage
+
+Run the provided script to send the request using `curl`.
+
+```
+./call_api.sh
+```
+
+The script sends the JSON payload and prints the API response.

--- a/testauth/call_api.sh
+++ b/testauth/call_api.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+API_URL="https://user.monocle-dev.wld.ssdgws.co.uk/api/v0/client/authorise"
+
+curl -X POST "$API_URL" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "clientId": "client-001",
+  "clientSecret": "auth-secret-for-client-001",
+  "scopes": ["ORGANISATION", "PATIENT"]
+}'


### PR DESCRIPTION
## Summary
- create `testauth` folder
- add README with example payload and usage
- add shell script to POST JSON payload to API endpoint

## Testing
- `bash -n testauth/call_api.sh`
